### PR TITLE
update default logging destination

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ dnsmasq_host_resolvers: [ "127.0.0.1" ]
 # contains at least one '/' character, it is taken to be a filename, and dnsmasq 
 # logs to the given file, instead of syslog. If the facility is '-' then dnsmasq 
 # logs to stderr.
-dnsmasq_conf_log: /var/log/dnsmasq.log
+dnsmasq_conf_log: DAEMON
 
 # Enable asynchronous logging and optionally set the limit on the number of 
 # lines which will be queued by dnsmasq when writing to the syslog is slow.


### PR DESCRIPTION
For "dnsmasq_conf_log" might "DAEMON" be a safer default value for most distributions?
Issues I have had on RHEL 7.3 are:
   * no SELinux file context exists for the file /var/log/dnsmasq.log.
   * no logrotate entry has been set by this role.